### PR TITLE
Make travis build lighter, by downloading pre-built qt and opencv.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
  - sudo ln -sf /usr/bin/g++-4.8 /usr/bin/g++;
 
 script:
- - make qt-windows
- - make opencv-windows
+ - make travis-ci-windows
  - make build-only-windows
  - make zip-only-windows

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ PRO_FILE=application/application.pro
 
 ## System info
 PWD=$(shell pwd)
-CPUS=$(shell nproc)
+ifeq (${TRAVIS}, 1)
+	CPUS=1
+else
+	CPUS=$(shell nproc)
+endif
 DATE=$(shell date "+%Y%m%d-%H%M")
 
 ## Third party libs
@@ -28,7 +32,7 @@ QMAKE_LIN=$(THIRD_PARTY_FLD)/qt/linux-install/bin/qmake
 WIN=windows
 WIN_BUILD_FLD=windows
 WIN_BUILD_TYPE=release
-WIN_FFMPEG_WRONG=$(THIRD_PARTY_FLD)/opencv/src-2.4.8/3rdparty/ffmpeg/opencv_ffmpeg.dll
+WIN_FFMPEG_WRONG=$(THIRD_PARTY_FLD)/opencv/windows-install/opencv_ffmpeg.dll
 WIN_FFMPEG_RIGHT=opencv_ffmpeg248.dll
 WIN_ZIP=$(PRO_NAME)-$(WIN)-$(DATE).zip
 
@@ -49,6 +53,9 @@ qt-windows:
 
 opencv-windows:
 	$(MAKE) -C $(THIRD_PARTY_FLD) opencv-windows
+
+travis-ci-windows:
+	$(MAKE) -C $(THIRD_PARTY_FLD) travis-ci-windows
 
 build-only-windows:
 	mkdir -p $(WIN_BUILD_FLD)
@@ -73,6 +80,9 @@ qt-linux:
 
 opencv-linux:
 	$(MAKE) -C $(THIRD_PARTY_FLD) opencv-linux
+
+travis-ci-linux:
+	$(MAKE) -C $(THIRD_PARTY_FLD) travis-ci-linux
 
 build-only-linux:
 	mkdir -p $(LIN_BUILD_FLD)

--- a/third-party/.gitignore
+++ b/third-party/.gitignore
@@ -2,9 +2,11 @@
 opencv/src*
 opencv/windows*
 opencv/linux*
+opencv/opencv-*
 qt/src*
 qt/windows*
 qt/linux*
+qt/qt-*
 ffmpeg/
 linux-install/
 libogg/

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -19,6 +19,14 @@ all: linux windows
 linux: qt-linux opencv-linux
 windows: qt-windows opencv-windows
 
+travis-ci-windows:
+	$(MAKE) -C $(OPENCV_FLD) windows-deploy-tbz
+	$(MAKE) -C $(QT_FLD) windows-deploy-tbz
+
+travis-ci-linux:
+	$(MAKE) -C $(OPENCV_FLD) linux-deploy-tbz
+	$(MAKE) -C $(QT_FLD) linux-deploy-tbz
+
 ################################################################################
 
 qt: qt-linux qt-windows

--- a/third-party/opencv/Makefile
+++ b/third-party/opencv/Makefile
@@ -7,7 +7,7 @@
 ################################################################################
 
 ## System info
-PWD=$(shell pwd)
+OPENCV_DIR=$(shell pwd)
 ifeq (${TRAVIS}, 1)
 	CPUS=1
 else
@@ -19,17 +19,24 @@ endif
 SRC_FLD=src
 SRC_GIT=https://github.com/Itseez/opencv.git
 
+PLACEHOLDER=PLACEHOLDER
+
 ## Windows stuff
 WIN_BUILD_FLD=windows-build
 WIN_INSTALL_FLD=windows-install
 WIN_VERSION=2.4.8
 WIN_SRC_FLD=src-$(WIN_VERSION)
+# WIN_TBZ_URL=
+WIN_TBZ=opencv-windows.tbz
+OPENCV_WIN_TBZ_URL=https://www.dropbox.com/s/z2ausk9ium7wepg/opencv-windows.tbz
 
 ## Linux stuff
 LIN_BUILD_FLD=linux-build
 LIN_INSTALL_FLD=linux-install
 LIN_VERSION=2.4.9
 LIN_SRC_FLD=src-$(LIN_VERSION)
+# LIN_TBZ_URL=
+LIN_TBZ=opencv-linux.tbz
 
 ################################################################################
 
@@ -103,6 +110,25 @@ windows: windows-src
       -D WITH_GSTREAMER=OFF \
       ../$(WIN_SRC_FLD)/
 	$(MAKE) -C $(WIN_BUILD_FLD) -j$(CPUS) install
+	cp $(WIN_SRC_FLD)/3rdparty/ffmpeg/opencv_ffmpeg.dll $(WIN_INSTALL_FLD)
+
+################################################################################
+
+linux-create-tbz: linux
+	tar -cjf $(LIN_TBZ) $(LIN_INSTALL_FLD)
+
+windows-create-tbz: windows
+	tar -cjf $(WIN_TBZ) $(WIN_INSTALL_FLD)
+
+linux-deploy-tbz:
+	rm -rf $(LIN_INSTALL_FLD)
+	wget --quiet $(OPENCV_LIN_TBZ_URL)
+	tar -xjf $(LIN_TBZ)
+
+windows-deploy-tbz:
+	rm -rf $(WIN_INSTALL_FLD)
+	wget --quiet $(OPENCV_WIN_TBZ_URL)
+	tar -xjf $(WIN_TBZ)
 
 ################################################################################
 
@@ -110,14 +136,18 @@ clean-linux-build:
 	rm -rf $(LIN_BUILD_FLD)
 clean-linux-install:
 	rm -rf $(LIN_INSTALL_FLD)
-clean-linux: clean-linux-build clean-linux-install
+clean-linux-tbz:
+	rm -f $(LIN_TBZ)
+clean-linux: clean-linux-build clean-linux-install clean-linux-tbz
 
 
 clean-windows-build:
 	rm -rf $(WIN_BUILD_FLD)
 clean-windows-install:
 	rm -rf $(WIN_INSTALL_FLD)
-clean-windows: clean-windows-build clean-windows-install
+clean-windows-tbz:
+	rm -f $(WIN_TBZ)
+clean-windows: clean-windows-build clean-windows-install clean-windows-tbz
 
 clean-src: clean-linux-src clean-windows-src
 clean-windows-src:

--- a/third-party/qt/Makefile
+++ b/third-party/qt/Makefile
@@ -7,7 +7,7 @@
 ################################################################################
 
 ## System info
-PWD=$(shell pwd)
+QT_DIR=$(shell pwd)
 ifeq (${TRAVIS}, 1)
 	CPUS=1
 else
@@ -19,13 +19,20 @@ endif
 SRC_FLD=src
 SRC_GIT=git://gitorious.org/qt/qt5.git
 
+PLACEHOLDER=PLACEHOLDER
+
 ## Windows stuff
 WIN_BUILD_FLD=windows-build
 WIN_INSTALL_FLD=windows-install
+# WIN_TBZ_URL=
+WIN_TBZ=qt-windows.tbz
+QT_WIN_TBZ_URL=https://www.dropbox.com/s/n8rqjzxeh30yl40/qt-windows.tbz
 
 ## Linux stuff
 LIN_BUILD_FLD=linux-build
 LIN_INSTALL_FLD=linux-install
+# LIN_TBZ_URL=
+LIN_TBZ=qt-linux.tbz
 
 ################################################################################
 
@@ -96,17 +103,43 @@ windows: windows-src
 
 ################################################################################
 
+linux-create-tbz: linux
+	tar -cjf $(LIN_TBZ) $(LIN_INSTALL_FLD)
+
+windows-create-tbz: windows
+	tar -cjf $(WIN_TBZ) $(WIN_INSTALL_FLD)
+
+linux-deploy-tbz:
+	rm -rf $(LIN_INSTALL_FLD)
+	wget --quiet $(QT_LIN_TBZ_URL)
+	tar -xjf $(LIN_TBZ)
+	sed -i "s|$(PLACEHOLDER)|$(QT_DIR)/$(LIN_INSTALL_FLD)|g" qt.conf
+	cp qt.conf $(WIN_INSTALL_FLD)/bin/
+
+windows-deploy-tbz:
+	rm -rf $(WIN_INSTALL_FLD)
+	wget --quiet $(QT_WIN_TBZ_URL)
+	tar -xjf $(WIN_TBZ)
+	sed -i "s|$(PLACEHOLDER)|$(QT_DIR)/$(WIN_INSTALL_FLD)|g" qt.conf
+	cp qt.conf $(WIN_INSTALL_FLD)/bin/
+
+################################################################################
+
 clean-linux-build:
 	rm -rf $(LIN_BUILD_FLD)
 clean-linux-install:
 	rm -rf $(LIN_INSTALL_FLD)
-clean-linux: clean-linux-build clean-linux-install
+clean-linux-tbz:
+	rm -f $(LIN_TBZ)
+clean-linux: clean-linux-build clean-linux-install clean-linux-tbz
 
 clean-windows-build:
 	rm -rf $(WIN_BUILD_FLD)
 clean-windows-install:
 	rm -rf $(WIN_INSTALL_FLD)
-clean-windows: clean-windows-build clean-windows-install
+clean-windows-tbz:
+	rm -f $(WIN_TBZ)
+clean-windows: clean-windows-build clean-windows-install clean-windows-tbz
 
 clean-src:
 	rm -rf $(SRC_FLD)

--- a/third-party/qt/qt.conf
+++ b/third-party/qt/qt.conf
@@ -1,0 +1,2 @@
+[Paths]
+Prefix = PLACEHOLDER


### PR DESCRIPTION
- Add ffmpeg to windows build.
- Don't sed opencv build.
- Single threaded make in Travis.
- Use qt.conf to personalize build.
- Correct extraction command.
